### PR TITLE
build(deps): remove unused Hexo packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ node_modules/
 public/
 .deploy*/
 .idea
-_docs/
+
+# Track shared docs and memories, but keep individual plan files local.
+_docs/_plans/**
+!_docs/_plans/.gitkeep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@
 
 This repository is a Hexo 8 static blog for `https://flc.io`, primarily written in Chinese. Blog content lives in `source/_posts/`, usually grouped by year such as `source/_posts/2025/`. Drafts live in `source/_drafts/` and are not published until moved or published by Hexo. Static pages are under directories such as `source/about/` and `source/open-source/`. Site assets live in `source/assets/`. `source/labs/**` and `source/shared/**` are excluded from Hexo rendering via `_config.yml` and should be treated as standalone static content. Do not edit generated `public/` output directly.
 
-Project working notes live under `_docs/`. Use `_docs/_plans/` for task plans, phased checklists, and execution notes that help coordinate longer work. Use `_docs/_memories/` for reusable project context that should survive across long-running tasks.
+Project working notes live under `_docs/`. Use `_docs/_plans/` for task plans, phased checklists, and execution notes that help coordinate longer work. The `_docs/_plans/` directory is tracked, but individual plan files are local-only and should stay ignored. Use `_docs/_memories/` for reusable project context that should survive across long-running tasks.
 
 ## Plans & Memories
 
-When working on a long task, read relevant files in `_docs/_plans/` and `_docs/_memories/` before making assumptions. If you discover generally useful project information during execution, dynamically update `_docs/_memories/` so future work can reuse it. Keep memories global and durable: prefer project conventions, dependency constraints, release practices, validation habits, and known architectural facts over one-off command logs or temporary status.
+When working on a long task, read relevant local files in `_docs/_plans/` and tracked files in `_docs/_memories/` before making assumptions. If you discover generally useful project information during execution, dynamically update `_docs/_memories/` so future work can reuse it. Keep memories global and durable: prefer project conventions, dependency constraints, release practices, validation habits, and known architectural facts over one-off command logs or temporary status.
 
 ## Build, Test, and Development Commands
 

--- a/_docs/_memories/project-context.md
+++ b/_docs/_memories/project-context.md
@@ -1,0 +1,100 @@
+# Project Context Memory
+
+## Repository Identity
+
+- Repository: `flc1125/flc.io`.
+- Site URL: `https://flc.io/`.
+- Project type: personal Hexo blog and static site.
+- Primary language/content locale: Chinese, configured as `zh-CN`.
+- Timezone: `Asia/Shanghai`.
+- Default branch observed locally: `master`.
+
+## Runtime And Build Model
+
+- Package manager: npm, with `package-lock.json` committed.
+- The project currently has production dependencies only; no `devDependencies`
+  are declared.
+- `package.json` declares `engines.node >=20.19.0` to match the current Hexo
+  dependency floor.
+- Main scripts:
+  - `npm run clean` runs `hexo clean`.
+  - `npm run build` runs `hexo generate`.
+  - `npm run server` runs `hexo server`.
+  - `npm run deploy` runs `hexo deploy`.
+- Hexo source directory is `source`; generated output goes to `public`.
+- Hexo theme is `icarus`.
+
+## Routing And Deployment Notes
+
+- `www.flc.io` redirects permanently to `https://flc.io/$1`.
+- `blog.flc.io` redirects permanently to `https://flc.io/$1`.
+- `/labs/filament-manager/(.*)` redirects permanently to `https://fil.flc.io/$1`.
+- `_config.yml` skips Hexo rendering for `labs/**` and `shared/**`.
+
+## Release Notes
+
+- Releases use version-like tags such as `v3.1`, `v3.2`, and `v3.3`.
+- `v3.3` was created on GitHub from `master` after `v3.2`.
+- When preparing future releases, check both local tags and GitHub releases
+  before creating a new tag.
+
+## Dependency Maintenance Notes
+
+- Direct npm dependencies are mostly Hexo core packages, Hexo generators,
+  renderers, themes, and plugins.
+- `package-lock.json` may already contain newer resolved versions than the
+  ranges in `package.json`; compare both before assuming an upgrade is needed.
+- Recent dependency review found these direct ranges worth syncing:
+  - `hexo`: `^8.0.0` to `^8.1.1`
+  - `hexo-renderer-marked`: `^7.0.0` to `^7.0.1`
+  - `hexo-theme-icarus`: `^6.1.0` to `^6.1.1`
+- `hexo-theme-landscape` was removed because the site uses `theme: icarus` and
+  no repository files reference Landscape outside dependency metadata.
+- `hexo-renderer-ejs` was removed because the active Icarus theme uses
+  JSX/Inferno and the repository has no first-party `.ejs` templates.
+- `hexo-tag-aplayer` was removed because it is stale and pulled vulnerable
+  older transitive dependencies through `hexo-fs`, `hexo-util`, `chokidar`,
+  `micromatch`, `braces`, and `highlight.js`.
+- Two posts previously using `{% meting %}` no longer embed music players.
+- `hexo-admonition` was removed because no posts used its `!!!` syntax and it
+  pulled an older vulnerable `markdown-it` range.
+- npm `overrides` were tested for `hexo-tag-aplayer`, but broad overrides broke
+  plugin loading or Hexo/Icarus dependency checks. Prefer plugin replacement
+  over overrides for this specific package.
+- Current dependency cleanup target: `npm audit --package-lock-only` should
+  report 0 vulnerabilities after install.
+
+## Verification Habits
+
+- For dependency changes, run:
+  - `npm install`
+  - `npm run clean`
+  - `npm run build`
+  - `npm audit --package-lock-only`
+- If `node_modules` is absent, `npm list --depth=0` reports missing packages;
+  use `package-lock.json` for installed/resolved version inspection until
+  dependencies are installed.
+- For security work, separate findings that npm can fix through lockfile
+  updates from findings that require plugin replacement or explicit overrides.
+- After removing music embeds, inspect generated `public/follow-your-dream/`
+  and `public/ponder/` output to confirm they no longer contain `meting-js`,
+  APlayer, or MetingJS resource tags.
+
+## Local Planning Conventions
+
+- Files in `_docs/_plans/` should use ordered, dated, status-bearing names:
+  `NNN-YYYY-MM-DD-status-short-topic.md`.
+- Use three-digit sequence numbers to preserve chronological order, such as
+  `001`, `002`, and `003`.
+- Use the plan creation date in local calendar format, such as `2026-04-25`.
+- Use status values that describe the current execution state:
+  `planned`, `in-progress`, `blocked`, or `completed`.
+- When a plan status changes, rename the file to keep the filename status in
+  sync with the checklist state.
+
+## Branching Notes
+
+- A dependency upgrade branch named `upgrade-dependencies` was created from
+  `master`.
+- Slash-separated branch names may fail in this local checkout due to Git ref
+  creation behavior; a simple non-slash branch name worked.

--- a/_docs/_plans/.gitkeep
+++ b/_docs/_plans/.gitkeep
@@ -1,0 +1,1 @@
+# Keep the tracked plans directory while individual plan files stay local.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,10 @@
         "hexo-generator-index": "^4.0.0",
         "hexo-generator-sitemap": "^3.0.1",
         "hexo-generator-tag": "^2.0.0",
-        "hexo-renderer-ejs": "^2.0.0",
         "hexo-renderer-marked": "^7.0.1",
         "hexo-renderer-stylus": "^3.0.1",
         "hexo-server": "^3.0.0",
-        "hexo-theme-icarus": "^6.1.1",
-        "hexo-theme-landscape": "^1.1.0"
+        "hexo-theme-icarus": "^6.1.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1867,11 +1865,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2414,20 +2407,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.4.tgz",
@@ -2621,35 +2600,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -3409,17 +3359,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/hexo-renderer-ejs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hexo-renderer-ejs/-/hexo-renderer-ejs-2.0.0.tgz",
-      "integrity": "sha512-qCjE1IdwgDgv65qyb0KMVCwCdSVAkH0vwAe9XihjvaKWkmb9dtt8DgErOdqCXn0HReSyWiEVP2BrLRj3gyHwOQ==",
-      "dependencies": {
-        "ejs": "^3.1.6"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/hexo-renderer-inferno": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hexo-renderer-inferno/-/hexo-renderer-inferno-1.0.2.tgz",
@@ -3672,12 +3611,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/hexo-theme-landscape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hexo-theme-landscape/-/hexo-theme-landscape-1.1.0.tgz",
-      "integrity": "sha512-nszjixBEiEDZjf7glAGbHg0nKGHZdUDwzFVVdRDeu4FeHfGcY5CZNl9sF4vSligjnD8IwFXpDfx5E+GRmNKvWg==",
-      "license": "MIT"
     },
     "node_modules/hexo-util": {
       "version": "4.0.0",
@@ -4104,87 +4037,6 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/jake": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-      "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/jake/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jake/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/jake/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/jake/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jake/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,9 @@
     "hexo-generator-index": "^4.0.0",
     "hexo-generator-sitemap": "^3.0.1",
     "hexo-generator-tag": "^2.0.0",
-    "hexo-renderer-ejs": "^2.0.0",
     "hexo-renderer-marked": "^7.0.1",
     "hexo-renderer-stylus": "^3.0.1",
     "hexo-server": "^3.0.0",
-    "hexo-theme-icarus": "^6.1.1",
-    "hexo-theme-landscape": "^1.1.0"
+    "hexo-theme-icarus": "^6.1.1"
   }
 }


### PR DESCRIPTION
## Summary
Remove unused Hexo packages that are no longer needed after the site standardized on the Icarus theme.

## Changes
- Remove `hexo-theme-landscape` because `_config.yml` uses `theme: icarus`
- Remove `hexo-renderer-ejs` because the repository has no first-party EJS templates and Icarus renders through JSX/Inferno
- Refresh `package-lock.json` after removing the unused dependency chain

## Motivation
- Keep the direct dependency list aligned with the active Hexo configuration
- Reduce unused packages and transitive dependencies in the install graph

## Testing
- `npm install`
- `npm run clean`
- `npm run build`
- `npm audit --package-lock-only` (`found 0 vulnerabilities`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Landscape theme option from the project.
  * Removed the EJS template renderer option from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->