### PR TITLE
docs: remove stale project references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,0 @@
-## 2023-01-16
-
-- Hexo version upgraded from 5.4.1 -> 9.3.0
-- Hexo icarus theme upgraded from 4.0.0 -> 5.1.0
-- Packages upgraded from 2021-01-16
-- Github Actions upgraded from 2021-01-16

--- a/README.md
+++ b/README.md
@@ -1,44 +1,27 @@
 # https://flc.io
 
-[![Deploy Site](https://github.com/flc1125/blog.flc.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/flc1125/blog.flc.io/actions/workflows/deploy.yml)
+个人博客，[博客说明](https://flc.io/hello-world/)。
 
-个人博客，[博客说明](https://flc.io/hello-world/)
+## Links
 
-## Categories
+- [首页](https://flc.io/)
+- [归档](https://flc.io/archives/)
+- [分类](https://flc.io/categories/)
+- [标签](https://flc.io/tags/)
+- [开源](https://flc.io/open-source/)
+- [关于](https://flc.io/about/)
 
-- [摘录](https://flc.io/categories/%E6%91%98%E5%BD%95/)
-- [编程](https://flc.io/categories/%E7%BC%96%E7%A8%8B/)
-  - [LeetCode](https://flc.io/categories/%E7%BC%96%E7%A8%8B/LeetCode/)
-  - [前端](https://flc.io/categories/%E7%BC%96%E7%A8%8B/%E5%89%8D%E7%AB%AF/)
-  - [后端](https://flc.io/categories/%E7%BC%96%E7%A8%8B/%E5%90%8E%E7%AB%AF/)
-  - [工具](https://flc.io/categories/%E7%BC%96%E7%A8%8B/%E5%B7%A5%E5%85%B7/)
-- [阅读](https://flc.io/categories/%E9%98%85%E8%AF%BB/)
-- [随记](https://flc.io/categories/%E9%9A%8F%E8%AE%B0/)
+## Development
 
-## Tags
+- `npm install`: install dependencies.
+- `npm run server`: start local Hexo server.
+- `npm run build`: generate static output.
+- `npm run clean`: remove generated output and cache.
 
-- [Elasticsearch](https://flc.io/tags/Elasticsearch/)
-- [Flag](https://flc.io/tags/Flag/)
-- [Git](https://flc.io/tags/Git/)
-- [Go](https://flc.io/tags/Go/)
-- [LeetCode](https://flc.io/tags/LeetCode/)
-- [OpenSSL](https://flc.io/tags/OpenSSL/)
-- [PHP0](https://flc.io/tags/PHP0/)
-- [PWA](https://flc.io/tags/PWA/)
-- [Redis](https://flc.io/tags/Redis/)
-- [Swoole](https://flc.io/tags/Swoole/)
-- [manifest](https://flc.io/tags/manifest/)
-- [二分查找](https://flc.io/tags/二分查找/)
-- [二叉树](https://flc.io/tags/二叉树/)
-- [动态规划](https://flc.io/tags/动态规划/)
-- [堆栈](https://flc.io/tags/堆栈/)
-- [快慢指针](https://flc.io/tags/快慢指针/)
-- [教程](https://flc.io/tags/教程/)
-- [村上春树](https://flc.io/tags/村上春树/)
-- [笔记](https://flc.io/tags/笔记/)
-- [规范](https://flc.io/tags/规范/)
-- [链表](https://flc.io/tags/链表/)
+## Repository
+
+- [flc1125/flc.io](https://github.com/flc1125/flc.io)
 
 ## Powered by
 
-© 2017-2024 Flc
+© 2017-2026 Flc

--- a/_config.icarus.yml
+++ b/_config.icarus.yml
@@ -52,7 +52,7 @@ navbar:
     links:
         Download on GitHub:
             icon: fab fa-github
-            url: 'https://github.com/flc1125/blog.flc.io'
+            url: 'https://github.com/flc1125/flc.io'
 footer:
     copyright: '<a href="https://beian.miit.gov.cn/" target="_blank">粤ICP备15063901号</a>'
     links:

--- a/_docs/_memories/project-context.md
+++ b/_docs/_memories/project-context.md
@@ -50,6 +50,8 @@
   - `hexo-theme-icarus`: `^6.1.0` to `^6.1.1`
 - `hexo-theme-landscape` was removed because the site uses `theme: icarus` and
   no repository files reference Landscape outside dependency metadata.
+- The old `_config.landscape.yml` file was removed after the Landscape package
+  was removed.
 - `hexo-renderer-ejs` was removed because the active Icarus theme uses
   JSX/Inferno and the repository has no first-party `.ejs` templates.
 - `hexo-tag-aplayer` was removed because it is stale and pulled vulnerable

--- a/source/_posts/2021/hello-world.md
+++ b/source/_posts/2021/hello-world.md
@@ -25,7 +25,7 @@ cover: https://s.flc.io/202301171621594.png!blog
 
 ### 技术栈
 
-- [Github](https://github.com/flc1125/flc.io)：托管本博客内容、代码平台；自动化构建、发布。
+- [GitHub](https://github.com/flc1125/flc.io)：托管本博客内容、代码平台；自动化构建、发布。
 - [Hexo](https://hexo.io/)：博客基础框架
 - [hexo-theme-icarus](https://github.com/ppoffice/hexo-theme-icarus)：博客主题
 - [node](https://nodejs.org/)：JavaScript 运行环境

--- a/source/_posts/2021/hello-world.md
+++ b/source/_posts/2021/hello-world.md
@@ -25,7 +25,7 @@ cover: https://s.flc.io/202301171621594.png!blog
 
 ### 技术栈
 
-- [Github](https://github.com/flc1125/blog.flc.io)：托管本博客内容、代码平台；自动化构建、发布。
+- [Github](https://github.com/flc1125/flc.io)：托管本博客内容、代码平台；自动化构建、发布。
 - [Hexo](https://hexo.io/)：博客基础框架
 - [hexo-theme-icarus](https://github.com/ppoffice/hexo-theme-icarus)：博客主题
 - [node](https://nodejs.org/)：JavaScript 运行环境

--- a/source/labs/space-bridge/GEMINI.md
+++ b/source/labs/space-bridge/GEMINI.md
@@ -1,6 +1,6 @@
 # Gemini Context: Spacebridge
 
-**Spacebridge** is a lightweight "cloud clipboard" application designed to easily share text and files between devices using a temporary 6-digit code. It is a single-page application (SPA) embedded within the `blog.flc.io` project.
+**Spacebridge** is a lightweight "cloud clipboard" application designed to easily share text and files between devices using a temporary 6-digit code. It is a single-page application (SPA) embedded within the `flc.io` project.
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary
Clean up stale project references that remained after the site moved to the current `flc1125/flc.io` repository and Icarus-only theme setup.

## Changes
- Remove the obsolete `CHANGELOG` and empty Landscape theme config
- Replace old `flc1125/blog.flc.io` repository links with `flc1125/flc.io`
- Simplify README links and development commands
- Update tracked project memory with the removed Landscape config note

## Motivation
- Avoid misleading future maintenance with stale theme and repository references
- Keep project documentation aligned with the active Hexo/Icarus setup

## Testing
- `npm run build`